### PR TITLE
add test for e4s 20.10 module

### DIFF
--- a/buildspecs/apps/spack/spack_check.yml
+++ b/buildspecs/apps/spack/spack_check.yml
@@ -27,4 +27,16 @@ buildspecs:
         stream: stdout
         exp: "^(0.14.2)"
 
-
+  e4s_20_10_spack:
+    type: script
+    executor: local.bash
+    tags: ["spack", "e4s"]
+    description: Check e4s/20.10 spack instance
+    run: |
+      module use /global/common/software/spackecp/modfile
+      module load e4s/20.10
+      spack --version
+    status:
+      regex:
+        stream: stdout
+        exp: "^(0.15.4-1620-e1e0bbb4c)$"


### PR DESCRIPTION
@adityakavalur adding test for e4s/20.10 module.

Here is sample build and output of test
```
(buildtest) siddiq90@cori03:~/buildtest-cori/buildspecs/apps/spack> buildtest build -b spack_check.yml 

+-------------------------------+
| Stage: Discovering Buildspecs |
+-------------------------------+ 
    

Discovered Buildspecs:
 
/global/u1/s/siddiq90/buildtest-cori/buildspecs/apps/spack/spack_check.yml

+---------------------------+
| Stage: Parsing Buildspecs |
+---------------------------+ 
    
 schemafile              | validstate   | buildspec
-------------------------+--------------+----------------------------------------------------------------------------
 script-v1.0.schema.json | True         | /global/u1/s/siddiq90/buildtest-cori/buildspecs/apps/spack/spack_check.yml

+----------------------+
| Stage: Building Test |
+----------------------+ 

 name                  | id       | type   | executor   | tags             | testpath
-----------------------+----------+--------+------------+------------------+------------------------------------------------------------------------------------------------------------
 spack_default_module  | 1190aa8a | script | local.bash | ['spack']        | /global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/spack_default_module/0/stage/generate.sh
 default_spack_version | 2df1c1ee | script | local.bash | ['spack']        | /global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/default_spack_version/0/stage/generate.sh
 e4s_20_10_spack       | 765dce3a | script | local.bash | ['spack', 'e4s'] | /global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/e4s_20_10_spack/0/stage/generate.sh



+----------------------+
| Stage: Running Test  |
+----------------------+ 
    
 name                  | id       | executor   | status   |   returncode | testpath
-----------------------+----------+------------+----------+--------------+------------------------------------------------------------------------------------------------------------
 spack_default_module  | 1190aa8a | local.bash | PASS     |            0 | /global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/spack_default_module/0/stage/generate.sh
 default_spack_version | 2df1c1ee | local.bash | PASS     |            0 | /global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/default_spack_version/0/stage/generate.sh
 e4s_20_10_spack       | 765dce3a | local.bash | PASS     |            0 | /global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/e4s_20_10_spack/0/stage/generate.sh

+----------------------+
| Stage: Test Summary  |
+----------------------+ 

Executed 3 tests
Passed Tests: 3/3 Percentage: 100.000%
Failed Tests: 0/3 Percentage: 0.000%



(buildtest) siddiq90@cori03:~/buildtest-cori/buildspecs/apps/spack> buildtest inspect 765dce3a
{
  "id": "765dce3a",
  "full_id": "765dce3a-be7a-4e49-9965-f5c77977bb4f",
  "testroot": "/global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/e4s_20_10_spack/0",
  "testpath": "/global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/e4s_20_10_spack/0/stage/generate.sh",
  "command": "/global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/e4s_20_10_spack/0/stage/generate.sh",
  "outfile": "/global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/e4s_20_10_spack/0/run/e4s_20_10_spack.out",
  "errfile": "/global/u1/s/siddiq90/buildtest/var/tests/local.bash/spack_check/e4s_20_10_spack/0/run/e4s_20_10_spack.err",
  "schemafile": "script-v1.0.schema.json",
  "executor": "local.bash",
  "tags": "spack e4s",
  "starttime": "2021/02/08 10:57:07",
  "endtime": "2021/02/08 10:57:11",
  "runtime": 3.200541670899838,
  "state": "PASS",
  "returncode": 0,
  "job": null
}



Output File
______________________________
0.15.4-1620-e1e0bbb4c




Error File
______________________________




Test Content
______________________________
#!/bin/bash 
source /global/u1/s/siddiq90/buildtest/var/executors/local.bash/before_script.sh
module use /global/common/software/spackecp/modfile
module load e4s/20.10
spack --version

source /global/u1/s/siddiq90/buildtest/var/executors/local.bash/after_script.sh



buildspec:  /global/u1/s/siddiq90/buildtest-cori/buildspecs/apps/spack/spack_check.yml
______________________________
version: "1.0"
buildspecs:
  spack_default_module:
    type: script
    description: "Test default spack module to see if some basic commands work"
    executor: local.bash
    tags: ["spack"]
    run: |
      module load spack
      spack --version
      spack arch
      spack find
      spack compiler list
      spack spec python
      spack info openmpi

  default_spack_version:
    type: script
    executor: local.bash
    tags: ["spack"]
    description: Default spack version should be 0.14.2
    run: |
      module load spack
      spack --version
    status:
      regex:
        stream: stdout
        exp: "^(0.14.2)"

  e4s_20_10_spack:
    type: script
    executor: local.bash
    tags: ["spack", "e4s"]
    description: Check e4s/20.10 spack instance
    run: |
      module use /global/common/software/spackecp/modfile
      module load e4s/20.10
      spack --version
    status:
      regex:
        stream: stdout
        exp: "^(0.15.4-1620-e1e0bbb4c)$"

```