### PR TITLE
increase poll time to 60sec and add compile qos test

### DIFF
--- a/.buildtest/config.yml
+++ b/.buildtest/config.yml
@@ -2,7 +2,7 @@ load_default_buildspecs: false
 moduletool: environment-modules
 executors:
   defaults:
-    pollinterval: 10
+    pollinterval: 60
     launcher: sbatch
     max_pend_time: 90
   local:
@@ -70,6 +70,12 @@ executors:
       cluster: escori
       options:
       - -C haswell
+    compile:
+      description: compile qos jobs
+      qos: compile
+      cluster: escori
+      options:
+      - -N 1
     knl_debug:
       qos: debug
       cluster: cori

--- a/buildspecs/apps/spack/spack_check.yml
+++ b/buildspecs/apps/spack/spack_check.yml
@@ -33,7 +33,6 @@ buildspecs:
     tags: ["spack", "e4s"]
     description: Check e4s/20.10 spack instance
     run: |
-      module use /global/common/software/spackecp/modfile
       module load e4s/20.10
       spack --version
     status:

--- a/buildspecs/jobs/fail/submit_limit_test.yml
+++ b/buildspecs/jobs/fail/submit_limit_test.yml
@@ -29,3 +29,14 @@ buildspecs:
       regex:
         stream: stderr
         exp: "sbatch: error: QOSMaxSubmitJobPerUserLimit"
+  
+  compile_submit_limit_test:
+    type: script
+    executor: local.bash
+    description: Submitting 2 node job in compile queue will fail. 
+    tags: [jobs, fail]
+    run: sbatch -q compile -M escori -N 2 -t 40 --wrap="hostname"
+    status:
+      regex:
+        stream: stderr
+        exp: "sbatch: error: Batch job submission failed: Node count specification invalid" 

--- a/buildspecs/queues/compile.yml
+++ b/buildspecs/queues/compile.yml
@@ -1,0 +1,10 @@
+version: "1.0"
+buildspecs:
+  compile_qos_hostname:
+    description: run hostname through compile qos
+    type: script
+    executor: slurm.compile
+    sbatch:
+      - "-t 5"
+    run: hostname
+    tags: ["queues"]

--- a/buildspecs/queues/xfer.yml
+++ b/buildspecs/queues/xfer.yml
@@ -1,7 +1,7 @@
 version: "1.0"
 buildspecs:
   xfer_qos_hostname:
-    description: run hostname through bigmem qos
+    description: run hostname through xfer qos
     type: script
     executor: slurm.xfer
     sbatch:


### PR DESCRIPTION
Refactor spack e4s test we don't need to specify module use prior to
loading e4s/20.10 module
add compile executor for submitting jobs to "compile" qos.
Adding fail test when submitting 2 nodes to compile qos.
Update description for xfer qos