### PR TITLE
add openpmd-api test by running version check on binary openpmd-ls

### DIFF
--- a/buildspecs/apps/openpmd-api/openpmd-ls.yml
+++ b/buildspecs/apps/openpmd-api/openpmd-ls.yml
@@ -1,0 +1,18 @@
+version: "1.0"
+buildspecs:
+  openpmd_ls_version_e4s_21.05:
+    type: script
+    executor: cori.local.bash
+    description: Run openpmd-ls version check for e4s/21.05
+    tags: e4s
+    run: |
+      module load e4s/21.05
+      spack load openpmd-api@0.13.4
+      openpmd-ls --version
+    status:
+      regex:
+        stream: stdout
+        exp: '(openpmd-ls) \(openPMD-api\) 0.13.4'
+maintainers:
+  - ax3l
+  - shahzebsiddiqui


### PR DESCRIPTION
@ax3l please see if this test looks okay with you

Here is an example run for the test. The regular expression will match output line `openpmd-ls (openPMD-api) 0.13.4` in order for test to pass which will read stdout. 

```
(buildtest) siddiq90@cori02> buildtest build -b openpmd-ls.yml 


User:  siddiq90
Hostname:  cori02
Platform:  Linux
Current Time:  2021/08/12 09:27:30
buildtest path: /global/homes/s/siddiq90/github/buildtest/bin/buildtest
buildtest version:  0.10.1
python path: /global/homes/s/siddiq90/.conda/envs/buildtest/bin/python
python version:  3.8.8
Test Directory:  /global/u1/s/siddiq90/github/buildtest/var/tests
Configuration File:  /global/u1/s/siddiq90/.buildtest/config.yml
Command: /global/homes/s/siddiq90/github/buildtest/bin/buildtest build -b openpmd-ls.yml

+-------------------------------+
| Stage: Discovering Buildspecs |
+-------------------------------+ 

+----------------------------------------------------------------------------------------+
| Discovered Buildspecs                                                                  |
+========================================================================================+
| /global/u1/s/siddiq90/github/buildtest-cori/buildspecs/apps/openpmd-api/openpmd-ls.yml |
+----------------------------------------------------------------------------------------+
Discovered Buildspecs:  1
Excluded Buildspecs:  0
Detected Buildspecs after exclusion:  1

+---------------------------+
| Stage: Parsing Buildspecs |
+---------------------------+ 

 schemafile              | validstate   | buildspec
-------------------------+--------------+----------------------------------------------------------------------------------------
 script-v1.0.schema.json | True         | /global/u1/s/siddiq90/github/buildtest-cori/buildspecs/apps/openpmd-api/openpmd-ls.yml



name                          description
----------------------------  ------------------------------------------
openpmd_ls_version_e4s_21.05  Run openpmd-ls version check for e4s/21.05

+----------------------+
| Stage: Building Test |
+----------------------+ 

 name                         | id       | type   | executor        | tags   | testpath
------------------------------+----------+--------+-----------------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------
 openpmd_ls_version_e4s_21.05 | d0c58936 | script | cori.local.bash | e4s    | /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.bash/openpmd-ls/openpmd_ls_version_e4s_21.05/d0c58936/openpmd_ls_version_e4s_21.05_build.sh





+---------------------+
| Stage: Running Test |
+---------------------+ 

 name                         | id       | executor        | status   |   returncode
------------------------------+----------+-----------------+----------+--------------
 openpmd_ls_version_e4s_21.05 | d0c58936 | cori.local.bash | PASS     |            0

+----------------------+
| Stage: Test Summary  |
+----------------------+ 
    
Passed Tests: 1/1 Percentage: 100.000%
Failed Tests: 0/1 Percentage: 0.000%


Writing Logfile to: /tmp/buildtest_434cib2u.log
A copy of logfile can be found at $BUILDTEST_ROOT/buildtest.log -  /global/homes/s/siddiq90/github/buildtest/buildtest.log
```

Shown below is the output and generated script

```
(buildtest) siddiq90@cori02> buildtest inspect query -o -t openpmd_ls_version_e4s_21.05
______________________________ openpmd_ls_version_e4s_21.05 (ID: d0c58936-0341-4d94-9615-87efebb5746f) ______________________________
executor:  cori.local.bash
description:  Run openpmd-ls version check for e4s/21.05
state:  PASS
returncode:  0
runtime:  6.167426
starttime:  2021/08/12 09:27:30
endtime:  2021/08/12 09:27:36
************************* Start of Output File: /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.bash/openpmd-ls/openpmd_ls_version_e4s_21.05/d0c58936/openpmd_ls_version_e4s_21.05.out *************************
openpmd-ls (openPMD-api) 0.13.4
Copyright 2017-2020 openPMD contributors
Authors: Axel Huebl et al.
License: LGPLv3+
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

************************* End of Output File: /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.bash/openpmd-ls/openpmd_ls_version_e4s_21.05/d0c58936/openpmd_ls_version_e4s_21.05.out *************************

************************* Start of Test Path:  /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.bash/openpmd-ls/openpmd_ls_version_e4s_21.05/d0c58936/openpmd_ls_version_e4s_21.05.sh *************************
#!/bin/bash 
# Content of run section
module load e4s/21.05
spack load openpmd-api@0.13.4
openpmd-ls --version

************************* End of Test Path:  /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.bash/openpmd-ls/openpmd_ls_version_e4s_21.05/d0c58936/openpmd_ls_version_e4s_21.05.sh *************************


```

Just making sure this test fails  when i change the regular expression

```
diff --git a/buildspecs/apps/openpmd-api/openpmd-ls.yml b/buildspecs/apps/openpmd-api/openpmd-ls.yml
index 2c8d839..b44f4de 100644
--- a/buildspecs/apps/openpmd-api/openpmd-ls.yml
+++ b/buildspecs/apps/openpmd-api/openpmd-ls.yml
@@ -12,7 +12,7 @@ buildspecs:
     status:
       regex:
         stream: stdout
-        exp: '(openpmd-ls) \(openPMD-api\) 0.13.4'
+        exp: '(openpmd-ls) \(openPMD-api\) 0.13.5'
 maintainers:
   - ax3l
   - shahzebsiddiqui
```

Running the test with the above change we should expect *FAIL* in the status column

```
(buildtest) siddiq90@cori02> buildtest build -b openpmd-ls.yml 


User:  siddiq90
Hostname:  cori02
Platform:  Linux
Current Time:  2021/08/12 09:25:38
buildtest path: /global/homes/s/siddiq90/github/buildtest/bin/buildtest
buildtest version:  0.10.1
python path: /global/homes/s/siddiq90/.conda/envs/buildtest/bin/python
python version:  3.8.8
Test Directory:  /global/u1/s/siddiq90/github/buildtest/var/tests
Configuration File:  /global/u1/s/siddiq90/.buildtest/config.yml
Command: /global/homes/s/siddiq90/github/buildtest/bin/buildtest build -b openpmd-ls.yml

+-------------------------------+
| Stage: Discovering Buildspecs |
+-------------------------------+ 

+----------------------------------------------------------------------------------------+
| Discovered Buildspecs                                                                  |
+========================================================================================+
| /global/u1/s/siddiq90/github/buildtest-cori/buildspecs/apps/openpmd-api/openpmd-ls.yml |
+----------------------------------------------------------------------------------------+
Discovered Buildspecs:  1
Excluded Buildspecs:  0
Detected Buildspecs after exclusion:  1

+---------------------------+
| Stage: Parsing Buildspecs |
+---------------------------+ 

 schemafile              | validstate   | buildspec
-------------------------+--------------+----------------------------------------------------------------------------------------
 script-v1.0.schema.json | True         | /global/u1/s/siddiq90/github/buildtest-cori/buildspecs/apps/openpmd-api/openpmd-ls.yml



name                          description
----------------------------  ------------------------------------------
openpmd_ls_version_e4s_21.05  Run openpmd-ls version check for e4s/21.05

+----------------------+
| Stage: Building Test |
+----------------------+ 

 name                         | id       | type   | executor        | tags   | testpath
------------------------------+----------+--------+-----------------+--------+---------------------------------------------------------------------------------------------------------------------------------------------------------
 openpmd_ls_version_e4s_21.05 | 5a8c7230 | script | cori.local.bash | e4s    | /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.bash/openpmd-ls/openpmd_ls_version_e4s_21.05/5a8c7230/openpmd_ls_version_e4s_21.05_build.sh





+---------------------+
| Stage: Running Test |
+---------------------+ 

 name                         | id       | executor        | status   |   returncode
------------------------------+----------+-----------------+----------+--------------
 openpmd_ls_version_e4s_21.05 | 5a8c7230 | cori.local.bash | FAIL     |            0

+----------------------+
| Stage: Test Summary  |
+----------------------+ 
    
Passed Tests: 0/1 Percentage: 0.000%
Failed Tests: 1/1 Percentage: 100.000%


Writing Logfile to: /tmp/buildtest_1hhm2lqk.log
A copy of logfile can be found at $BUILDTEST_ROOT/buildtest.log -  /global/homes/s/siddiq90/github/buildtest/buildtest.log

```