### PR TITLE
fix bug with upcxx test for e4s/21.05

### DIFF
--- a/buildspecs/e4s/spack_test/upcxx.yml
+++ b/buildspecs/e4s/spack_test/upcxx.yml
@@ -1,11 +1,13 @@
 version: "1.0"
 buildspecs: 
-  spack_test_upcxx_e4s_21.02:
+  spack_test_upcxx_e4s_21.05:
     type: spack
     executor: cori.local.sh
     description: "Test upcxx@2021.03.0 for e4s/21.05 test via spack test"
     tags: e4s
-    pre_cmds: module load e4s/21.05
+    pre_cmds: |
+      module load e4s/21.05
+      module swap intel intel/19.1.3.304
     spack:
       root: /global/common/software/spackecp/e4s-21.05/spack/
       verify_spack: false


### PR DESCRIPTION
@PHHargrove @bonachea: let me know if this test results look okay. This should address #62 

I was able to fix this test turns out that we need to swap to the intel module that was used for building the stack since the default intel module is different. 

This is the spec we have for `e4s/21.05`
```
siddiq90@cori02> spack find --format "{name}@{version}%{compiler}" upcxx
upcxx@2021.3.0%intel@19.1.3.304
```

This is the compiler stanza for `intel@19.1.304`

```
siddiq90@cori02> spack compiler info intel@19.1.3.304
intel@19.1.3.304:
	paths:
		cc = cc
		cxx = CC
		f77 = ftn
		fc = ftn
	modules  = ['PrgEnv-intel', 'intel/19.1.3.304']
	operating system  = cnl7
```

So we just need to swap the intel module before running `spack test run` and it worked. I confirmed running with different intel module caused an error. `PrgEnv-intel` was loaded at startup so we didnt need to swap this though this behavior may change if user has different startup modules loaded such as other `PrgEnv-*` modules. 
```
(buildtest) siddiq90@cori02> buildtest build -b upcxx.yml 


User:  siddiq90
Hostname:  cori02
Platform:  Linux
Current Time:  2021/08/12 09:36:40
buildtest path: /global/homes/s/siddiq90/github/buildtest/bin/buildtest
buildtest version:  0.10.1
python path: /global/homes/s/siddiq90/.conda/envs/buildtest/bin/python
python version:  3.8.8
Test Directory:  /global/u1/s/siddiq90/github/buildtest/var/tests
Configuration File:  /global/u1/s/siddiq90/.buildtest/config.yml
Command: /global/homes/s/siddiq90/github/buildtest/bin/buildtest build -b upcxx.yml

+-------------------------------+
| Stage: Discovering Buildspecs |
+-------------------------------+ 

+---------------------------------------------------------------------------------+
| Discovered Buildspecs                                                           |
+=================================================================================+
| /global/u1/s/siddiq90/github/buildtest-cori/buildspecs/e4s/spack_test/upcxx.yml |
+---------------------------------------------------------------------------------+
Discovered Buildspecs:  1
Excluded Buildspecs:  0
Detected Buildspecs after exclusion:  1

+---------------------------+
| Stage: Parsing Buildspecs |
+---------------------------+ 

 schemafile             | validstate   | buildspec
------------------------+--------------+---------------------------------------------------------------------------------
 spack-v1.0.schema.json | True         | /global/u1/s/siddiq90/github/buildtest-cori/buildspecs/e4s/spack_test/upcxx.yml



name                        description
--------------------------  ------------------------------------------------------
spack_test_upcxx_e4s_21.05  Test upcxx@2021.03.0 for e4s/21.05 test via spack test

+----------------------+
| Stage: Building Test |
+----------------------+ 



 name                       | id       | type   | executor      | tags   | testpath
----------------------------+----------+--------+---------------+--------+----------------------------------------------------------------------------------------------------------------------------------------------
 spack_test_upcxx_e4s_21.05 | 529f5bdf | spack  | cori.local.sh | e4s    | /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.sh/upcxx/spack_test_upcxx_e4s_21.05/529f5bdf/spack_test_upcxx_e4s_21.05_build.sh



+---------------------+
| Stage: Running Test |
+---------------------+ 

 name                       | id       | executor      | status   |   returncode
----------------------------+----------+---------------+----------+--------------
 spack_test_upcxx_e4s_21.05 | 529f5bdf | cori.local.sh | PASS     |            0

+----------------------+
| Stage: Test Summary  |
+----------------------+ 
    
Passed Tests: 1/1 Percentage: 100.000%
Failed Tests: 0/1 Percentage: 0.000%


Writing Logfile to: /tmp/buildtest_3tf3me02.log
A copy of logfile can be found at $BUILDTEST_ROOT/buildtest.log -  /global/homes/s/siddiq90/github/buildtest/buildtest.log

```

Shown below is the generated output and test file

```
(buildtest) siddiq90@cori02> buildtest inspect query -o -t spack_test_upcxx_e4s_21.05
______________________________ spack_test_upcxx_e4s_21.05 (ID: 529f5bdf-b918-4ae5-9c1f-861a38c3e6e2) ______________________________
executor:  cori.local.sh
description:  Test upcxx@2021.03.0 for e4s/21.05 test via spack test
state:  PASS
returncode:  0
runtime:  30.073759
starttime:  2021/08/12 09:36:40
endtime:  2021/08/12 09:37:10
************************* Start of Output File: /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.sh/upcxx/spack_test_upcxx_e4s_21.05/529f5bdf/spack_test_upcxx_e4s_21.05.out *************************
==> Spack test upcxx@2021.03.0%intel
==> Testing package upcxx-2021.3.0-ufqtz47
==> Results for test suite 'upcxx@2021.03.0%intel', spec matching 'upcxx@2021.03.0%intel':
==>   upcxx-2021.3.0-ufqtz47 PASSED
==> Testing package upcxx-2021.3.0-ufqtz47
==> [2021-08-12-09:36:55.333332] Checking UPC++ compile+link for all installed backends
==> [2021-08-12-09:36:55.334707] '/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/test-upcxx-install.sh'
========
Testing the UPC++ install at /global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg
========
========
SUCCESS
========
/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/upcxx -codemode=debug -threadmode=seq -network=smp test-upcxx-7563.cpp -o test-upcxx-7563
/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/upcxx -codemode=debug -threadmode=seq -network=aries test-upcxx-7563.cpp -o test-upcxx-7563
/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/upcxx -codemode=debug -threadmode=par -network=smp test-upcxx-7563.cpp -o test-upcxx-7563
/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/upcxx -codemode=debug -threadmode=par -network=aries test-upcxx-7563.cpp -o test-upcxx-7563
/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/upcxx -codemode=opt -threadmode=seq -network=smp test-upcxx-7563.cpp -o test-upcxx-7563
/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/upcxx -codemode=opt -threadmode=seq -network=aries test-upcxx-7563.cpp -o test-upcxx-7563
/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/upcxx -codemode=opt -threadmode=par -network=smp test-upcxx-7563.cpp -o test-upcxx-7563
/global/common/software/spackecp/e4s-21.05/software/cray-cnl7-haswell/intel-19.1.3.304/upcxx-2021.3.0-ufqtz47fcwgffdcjqi6iuel6nqgnlarg/bin/upcxx -codemode=opt -threadmode=par -network=aries test-upcxx-7563.cpp -o test-upcxx-7563
PASSED

************************* End of Output File: /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.sh/upcxx/spack_test_upcxx_e4s_21.05/529f5bdf/spack_test_upcxx_e4s_21.05.out *************************

************************* Start of Test Path:  /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.sh/upcxx/spack_test_upcxx_e4s_21.05/529f5bdf/spack_test_upcxx_e4s_21.05.sh *************************
#!/bin/bash


######## START OF PRE COMMANDS ######## 
module load e4s/21.05
module swap intel intel/19.1.3.304

######## END OF PRE COMMANDS   ######## 


source /global/common/software/spackecp/e4s-21.05/spack/share/spack/setup-env.sh
spack test run  --alias upcxx@2021.03.0%intel upcxx@2021.03.0%intel
spack test results -l -- upcxx@2021.03.0%intel
************************* End of Test Path:  /global/u1/s/siddiq90/github/buildtest/var/tests/cori.local.sh/upcxx/spack_test_upcxx_e4s_21.05/529f5bdf/spack_test_upcxx_e4s_21.05.sh *************************
```