### PR TITLE
butterflypack test for e4s/21.05

### DIFF
--- a/buildspecs/e4s/e4s_21.05.yml
+++ b/buildspecs/e4s/e4s_21.05.yml
@@ -73,6 +73,20 @@ buildspecs:
       source ./setup.sh
       sh test-all.sh --color-off validation_tests/strumpack --print-logs --settings settings.cori.sh
 
+  e4s_butterflypack:
+    type: script
+    executor: cori.slurm.haswell_debug
+    description: Run ButterflyPACK test from E4S Testsuite
+    tags: [e4s]
+    sbatch: ["-t 30:00", "-N 1"]
+    run: |
+      module swap intel intel/19.1.3.304
+      module load e4s/21.05
+      git clone https://github.com/E4S-Project/testsuite
+      cd testsuite
+      source ./setup.sh
+      sh test-all.sh --color-off validation_tests/butterflypack --print-logs --settings settings.cori.sh
+
   e4s_tau.pdt.papi:
     type: script
     executor: cori.slurm.haswell_premium

--- a/buildspecs/e4s/e4s_21.05.yml
+++ b/buildspecs/e4s/e4s_21.05.yml
@@ -104,3 +104,4 @@ maintainers:
   - "@shahzebsiddiqui"
   - "@wspear"
   - "@pghysels"
+  - "@liuyangzhuan"


### PR DESCRIPTION
Adding butterflypack tests from e4s.

Note that I created a PR here https://github.com/E4S-Project/testsuite/pull/19. I've tested my fork of testsuite, buildtest-cori works as expected.